### PR TITLE
fix(TimeZoneDB): Fixes #3 where timestamps should be in UTC

### DIFF
--- a/spec/Provider/TimeZoneDBSpec.php
+++ b/spec/Provider/TimeZoneDBSpec.php
@@ -63,6 +63,12 @@ describe (TimeZoneDB::class, function () {
         expect ($tz->getUtcOffset())->toBeAn('int');
     });
 
+    it ('->find() has a timestamp in utc', function () {
+        $tz = $this->teazee->find($this->lat, $this->lng);
+
+        expect ($tz->getTimestamp())->toBe(1447744964);
+    });
+
     it ('->find() can check for daylight savings time', function () {
         $tz = $this->teazee->find($this->lat, $this->lng);
 

--- a/src/Provider/TimeZoneDB.php
+++ b/src/Provider/TimeZoneDB.php
@@ -55,7 +55,7 @@ class TimeZoneDB extends AbstractHttpProvider
         return $this->returnResult(array_merge($this->getDefaults(), [
             'id'        => $data->zoneName,
             'dst'       => (bool) $data->dst,
-            'timestamp' => $data->timestamp,
+            'timestamp' => $data->timestamp - $data->gmtOffset,
             'utcOffset' => $data->gmtOffset,
         ]));
     }


### PR DESCRIPTION
For TimeZoneDB, subtracting the `gmtOffset` value from the local `timestamp` value will yield the correct UNIX timestamp.
