### PR TITLE
Refactor specs into contexts

### DIFF
--- a/spec/Model/TimeZoneFactorySpec.php
+++ b/spec/Model/TimeZoneFactorySpec.php
@@ -61,7 +61,7 @@ describe(TimeZoneFactory::class, function () {
         });
 
         it ('has no utc offset', function () {
-            expect($this->tz->getUtcOffset())->toBe(0);
+            expect($this->tz->getUtcOffset())->toBeNull();
         });
 
         it ('has no timestamp', function () {

--- a/spec/Model/TimeZoneFactorySpec.php
+++ b/spec/Model/TimeZoneFactorySpec.php
@@ -67,6 +67,10 @@ describe(TimeZoneFactory::class, function () {
         it ('has no timestamp', function () {
             expect($this->tz->getTimestamp())->toBeNull();
         });
+
+        it ('has no DateTime', function () {
+            expect($this->tz->getDateTime())->toBeNull();
+        });
     });
 
     context ('with US Pacific', function () {
@@ -96,6 +100,10 @@ describe(TimeZoneFactory::class, function () {
             it ('->getTimestamp()', function () {
                 expect($this->tz->getTimestamp())->toBe(1446303600);
             });
+
+            it ('->getDateTime()', function () {
+                expect($this->tz->getDateTime()->format('Y-m-d H:i:s'))->toBe('2015-10-31 08:00:00');
+            });
         });
 
         context ('when not DST', function () {
@@ -121,6 +129,10 @@ describe(TimeZoneFactory::class, function () {
 
             it ('->getTimestamp()', function () {
                 expect($this->tz->getTimestamp())->toBe(1446480000);
+            });
+
+            it ('->getDateTime()', function () {
+                expect($this->tz->getDateTime()->format('Y-m-d H:i:s'))->toBe('2015-11-02 08:00:00');
             });
         });
     });

--- a/spec/Model/TimeZoneFactorySpec.php
+++ b/spec/Model/TimeZoneFactorySpec.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Teazee\Spec\Model;
+
+use Teazee\Model\TimeZoneFactory;
+use Teazee\Model\TimeZone;
+use DateTimeZone;
+
+describe(TimeZoneFactory::class, function () {
+    before (function () {
+        $this->factory = new TimeZoneFactory();
+    });
+
+    context ('with defaults', function () {
+        before (function () {
+            $this->defaults = [
+                'id'        => null,
+                'dst'       => null,
+                'utcOffset' => null,
+                'timestamp' => null,
+            ];
+
+            $this->closure = function () {
+                $this->tz = $this->factory->create($this->defaults);
+            };
+        });
+
+        it ('fails without a valid IANA TimeZone ID', function () {
+            expect($this->closure)->toThrow();
+        });
+    });
+
+    context ('with minimal values', function () {
+        before (function () {
+            $this->values = [
+                'id'        => 'UTC',
+                'dst'       => null,
+                'utcOffset' => null,
+                'timestamp' => null
+            ];
+        });
+
+        beforeEach (function () {
+            $this->tz = $this->factory->create($this->values);
+        });
+
+        it ('creates a ' . TimeZone::class, function () {
+            expect($this->tz)->toBeAnInstanceOf(TimeZone::class);
+        });
+
+        it ('->getDateTimeZone()', function () {
+            expect($this->tz->getDateTimeZone())->toBeAnInstanceOf(DateTimeZone::class);
+        });
+
+        it ('->getName()', function () {
+            expect($this->tz->getName())->toBe('UTC');
+        });
+
+        it ('is dst falsey', function () {
+            expect($this->tz->isDst())->toBeFalsy();
+        });
+
+        it ('has no utc offset', function () {
+            expect($this->tz->getUtcOffset())->toBe(0);
+        });
+
+        it ('has no timestamp', function () {
+            expect($this->tz->getTimestamp())->toBeNull();
+        });
+    });
+
+    context ('with US Pacific', function () {
+        before (function () {
+            $this->values = [
+                'id' => 'America/Los_Angeles'
+            ];
+        });
+
+        context ('when DST', function () {
+            before (function () {
+                $this->values = $this->values + [
+                    'dst'       => 1,
+                    'utcOffset' => -25200,
+                    'timestamp' => 1446303600
+                ];
+            });
+
+            beforeEach (function () {
+                $this->tz = $this->factory->create($this->values);
+            });
+
+            it ('->isDst()', function () {
+                expect($this->tz->isDst())->toBeTruthy();
+            });
+
+            it ('->getTimestamp()', function () {
+                expect($this->tz->getTimestamp())->toBe(1446303600);
+            });
+        });
+
+        context ('when not DST', function () {
+            before (function () {
+                $this->values = $this->values + [
+                    'dst'       => 0,
+                    'utcOffset' => -28800,
+                    'timestamp' => 1446480000
+                ];
+            });
+
+            beforeEach (function () {
+                $this->tz = $this->factory->create($this->values);
+            });
+
+            it ('->isDst()', function () {
+                expect($this->tz->isDst())->toBeFalsy();
+            });
+
+            it ('->getName()', function () {
+                expect($this->tz->getName())->toBe('America/Los_Angeles');
+            });
+
+            it ('->getTimestamp()', function () {
+                expect($this->tz->getTimestamp())->toBe(1446480000);
+            });
+        });
+    });
+});

--- a/spec/Provider/TimeZoneDBSpec.php
+++ b/spec/Provider/TimeZoneDBSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Teazee\Spec;
+namespace Teazee\Spec\Provider;
 
 use Http\Client\HttpClient;
 use Teazee\Model\TimeZone;
@@ -17,10 +17,6 @@ describe (TimeZoneDB::class, function () {
         $this->lng = -88.3121289;
     });
 
-    after (function() {
-        VCR::eject();
-    });
-
     beforeEach (function() {
         $this->teazee = new TimeZoneDB('TVDB_TEAZEE_KEY');
     });
@@ -33,79 +29,81 @@ describe (TimeZoneDB::class, function () {
         expect($this->teazee->getClient())->toBeAnInstanceOf(HttpClient::class);
     });
 
-    it ('->find() returns a TimeZone', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
+    context('with coordinates', function () {
 
-        expect ($tz)->toBeAnInstanceOf(TimeZone::class);
+        beforeEach (function () {
+           $this->tz = $this->teazee->find($this->lat, $this->lng);
+        });
+
+        it ('->find() returns a TimeZone', function () {
+            expect ($this->tz)->toBeAnInstanceOf(TimeZone::class);
+        });
+
+        it ('->find() has a DateTimeZone', function () {
+            expect ($this->tz->getDateTimeZone())->toBeAnInstanceOf(DateTimeZone::class);
+        });
+
+        it ('->find() has a name', function () {
+            expect ($this->tz->getName())->toBe('America/Chicago');
+        });
+
+        it ('->find() has a timestamp', function () {
+            expect ($this->tz->getTimestamp())->toBeAn('int');
+        });
+
+        it ('->find() has a utc offset', function () {
+            expect ($this->tz->getUtcOffset())->toBeAn('int');
+        });
+
+        it ('->find() has a timestamp in utc', function () {
+            expect ($this->tz->getTimestamp())->toBe(1447744964);
+        });
+
+        it ('->find() can check for daylight savings time', function () {
+            expect ($this->tz->isDst())->toBeFalsy();
+        });
     });
 
-    it ('->find() has a DateTimeZone', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
+    context ('with coordinates and timestamp', function () {
+        it ('->find() can take an optional timestamp', function () {
+            $this->tz = $this->teazee->find($this->lat, $this->lng, 1446296400);
 
-        expect ($tz->getDateTimeZone())->toBeAnInstanceOf(DateTimeZone::class);
+            expect ($this->tz->isDst())->toBe(true);
+        });
     });
 
-    it ('->find() has a name', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
+    context ('with invalid parameters', function () {
 
-        expect ($tz->getName())->toBe('America/Chicago');
+        it ('fails without an API key', function () {
+            $expected = function () {
+                $this->teazee = new TimeZoneDB('');
+                $this->teazee->find($this->lat, $this->lng);
+            };
+
+            expect ($expected)
+                ->toThrow(new RuntimeException('Parameter "key" (API Key) is not provided.'));
+        });
+
+        it ('fails with a bad API key', function () {
+            $expected = function () {
+                $this->teazee = new TimeZoneDB('TEAZEE_BAD_KEY');
+                $this->teazee->find($this->lat, $this->lng);
+            };
+
+            expect ($expected)
+                ->toThrow(new RuntimeException('Invalid API key.'));
+        });
+
+        it ('fails on invalid coordinates', function () {
+            $expected = function () {
+                $this->teazee->find('foo', 'bar');
+            };
+
+            expect ($expected)->toThrow(new RuntimeException('Invalid latitude value.'));
+        });
     });
 
-    it ('->find() has a timestamp', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
-
-        expect ($tz->getTimestamp())->toBeAn('int');
-    });
-
-    it ('->find() has a utc offset', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
-
-        expect ($tz->getUtcOffset())->toBeAn('int');
-    });
-
-    it ('->find() has a timestamp in utc', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
-
-        expect ($tz->getTimestamp())->toBe(1447744964);
-    });
-
-    it ('->find() can check for daylight savings time', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng);
-
-        expect ($tz->isDst())->toBe(false);
-    });
-
-    it ('->find() can take an optional timestamp', function () {
-        $tz = $this->teazee->find($this->lat, $this->lng, 1446296400);
-
-        expect ($tz->isDst())->toBe(true);
-    });
-
-    it ('fails without an API key', function () {
-        $expected = function () {
-            $this->teazee = new TimeZoneDB('');
-            $this->teazee->find($this->lat, $this->lng);
-        };
-
-        expect ($expected)
-            ->toThrow(new RuntimeException('Parameter "key" (API Key) is not provided.'));
-    });
-
-    it ('fails with a bad API key', function () {
-        $expected = function () {
-            $this->teazee = new TimeZoneDB('TEAZEE_BAD_KEY');
-            $this->teazee->find($this->lat, $this->lng);
-        };
-
-        expect ($expected)
-            ->toThrow(new RuntimeException('Invalid API key.'));
-    });
-
-    it ('fails on invalid params', function () {
-        $expected = function () {
-            $this->teazee->find('foo', 'bar');
-        };
-
-        expect ($expected)->toThrow(new RuntimeException('Invalid latitude value.'));
+    after (function() {
+        VCR::eject();
     });
 });

--- a/spec/Provider/TimeZoneDBSpec.php
+++ b/spec/Provider/TimeZoneDBSpec.php
@@ -39,28 +39,8 @@ describe (TimeZoneDB::class, function () {
             expect ($this->tz)->toBeAnInstanceOf(TimeZone::class);
         });
 
-        it ('->find() has a DateTimeZone', function () {
-            expect ($this->tz->getDateTimeZone())->toBeAnInstanceOf(DateTimeZone::class);
-        });
-
-        it ('->find() has a name', function () {
-            expect ($this->tz->getName())->toBe('America/Chicago');
-        });
-
-        it ('->find() has a timestamp', function () {
-            expect ($this->tz->getTimestamp())->toBeAn('int');
-        });
-
-        it ('->find() has a utc offset', function () {
-            expect ($this->tz->getUtcOffset())->toBeAn('int');
-        });
-
         it ('->find() has a timestamp in utc', function () {
             expect ($this->tz->getTimestamp())->toBe(1447744964);
-        });
-
-        it ('->find() can check for daylight savings time', function () {
-            expect ($this->tz->isDst())->toBeFalsy();
         });
     });
 

--- a/src/Model/TimeZone.php
+++ b/src/Model/TimeZone.php
@@ -38,7 +38,7 @@ final class TimeZone
     {
         $this->dateTimeZone = $zone;
         $this->dst = (bool) $dst;
-        $this->utcOffset = (int) $utcOffset;
+        $this->utcOffset = $utcOffset ? (int) $utcOffset : null;
         $this->timestamp = $timestamp ? (int) $timestamp : null;
     }
 

--- a/src/Model/TimeZone.php
+++ b/src/Model/TimeZone.php
@@ -27,6 +27,11 @@ final class TimeZone
     private $dateTimeZone;
 
     /**
+     * @var \DateTimeImmutable
+     */
+    private $dateTime;
+
+    /**
      * TimeZone Constructor.
      *
      * @param DateTimeZone $zone
@@ -37,9 +42,13 @@ final class TimeZone
     public function __construct(DateTimeZone $zone, $dst, $utcOffset, $timestamp)
     {
         $this->dateTimeZone = $zone;
-        $this->dst = (bool) $dst;
-        $this->utcOffset = $utcOffset ? (int) $utcOffset : null;
-        $this->timestamp = $timestamp ? (int) $timestamp : null;
+        $this->dst          = $dst ? (bool) $dst : null;
+        $this->utcOffset    = $utcOffset ? (int) $utcOffset : null;
+        $this->timestamp    = $timestamp ? (int) $timestamp : null;
+
+        if ($this->timestamp) {
+            $this->dateTime = (new \DateTimeImmutable('@'.$this->timestamp))->setTimezone($zone);
+        }
     }
 
     /**
@@ -48,6 +57,14 @@ final class TimeZone
     public function getName()
     {
         return $this->dateTimeZone->getName();
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getDateTime()
+    {
+        return $this->dateTime;
     }
 
     /**


### PR DESCRIPTION
- Add specs for `TimeZoneFactory`
- Fix return value for `TimeZone::getUtcOffset()` when no UTC offset provided.
- Add `TimeZone::getDateTime()`
