### PR TITLE
ZoneInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple interface to find the timezone and time offset data for a position on t
 
 * [Installation](#installation)
 * [Usage](#usage)
-  - [TimeZone](#timezone)
+  - [ZoneInfo](#zoneinfo)
   - [Providers](#providers)
     - [TimeZoneDB](#timezonedb)
   - [HTTP Clients](#http-clients)
@@ -30,17 +30,17 @@ The `Teazee` interface, which all providers implement, exposes a single method:
 
 * `find($lat, $lng, $timestamp)`
 
-### TimeZone
+### ZoneInfo
 
-The `find()` method returns a `TimeZone` object, which provides the following API:
+The `find()` method returns a `ZoneInfo` object, which extends PHP's [`DateTimeZone`](http://php.net/manual/en/class.datetimezone.php) and exposes the following additional methods:
 
-* `getName()` will return the [IANA Time Zone ID](http://www.iana.org/time-zones).
-* `getDateTimeZone()` will return a [`DateTimeZone`](http://php.net/manual/en/class.datetimezone.php) object for the [IANA TimeZone](http://www.iana.org/time-zones) returned from the Provider.
-* `getDateTime()` will return a [`DateTimeImmutable`](http://php.net/manual/en/class.datetimeimmutable.php) object representing the specified `timestamp` in the returned `DateTimeZone`.
+* `getDateTime()` will return a [`DateTimeImmutable`](http://php.net/manual/en/class.datetimeimmutable.php) representing the specified `timestamp`.
 * `getTimestamp()` will return a UNIX timestamp (`int`) for the specified `timestamp`. Generally this value is used to determine whether or not Daylight Savings Time should be applied. Not all providers require a timestamp. If the timestamp is required, but not provided, the current time will be used.
-* `getUtcOffset()` will return the offset from UTC (in seconds) for the given location.
-* `isDst()` will return a `boolean` representing whether or not the TimeZone is in Daylight Savings Time during the specified `timestamp`.
-* `getCountry()` will return the 2-digit country code the for `DateTimeZone`.
+* `getUtcOffset()` will return the offset (`int`) from UTC (in seconds) for the given location.
+* `isDst()` will return a `boolean` representing whether or not the timezone is in Daylight Savings Time during the specified `timestamp`.
+* `getCountry()` will return the 2-digit country code for the timezone.
+
+> **Note**: You can use `ZoneInfo` as a drop-in replacement for `DateTimeZone` in your code.
 
 
 ### Providers

--- a/spec/Model/ZoneInfoFactorySpec.php
+++ b/spec/Model/ZoneInfoFactorySpec.php
@@ -2,13 +2,13 @@
 
 namespace Teazee\Spec\Model;
 
-use Teazee\Model\TimeZoneFactory;
-use Teazee\Model\TimeZone;
+use Teazee\Model\ZoneInfoFactory;
+use Teazee\Model\ZoneInfo;
 use DateTimeZone;
 
-describe(TimeZoneFactory::class, function () {
+describe(ZoneInfoFactory::class, function () {
     before (function () {
-        $this->factory = new TimeZoneFactory();
+        $this->factory = new ZoneInfoFactory();
     });
 
     context ('with defaults', function () {
@@ -44,12 +44,12 @@ describe(TimeZoneFactory::class, function () {
             $this->tz = $this->factory->create($this->values);
         });
 
-        it ('creates a ' . TimeZone::class, function () {
-            expect($this->tz)->toBeAnInstanceOf(TimeZone::class);
+        it ('creates a ' . ZoneInfo::class, function () {
+            expect($this->tz)->toBeAnInstanceOf(ZoneInfo::class);
         });
 
-        it ('->getDateTimeZone()', function () {
-            expect($this->tz->getDateTimeZone())->toBeAnInstanceOf(DateTimeZone::class);
+        it ('is a ' . DateTimeZone::class, function () {
+            expect($this->tz)->toBeAnInstanceOf(DateTimeZone::class);
         });
 
         it ('->getName()', function () {

--- a/spec/Provider/TimeZoneDBSpec.php
+++ b/spec/Provider/TimeZoneDBSpec.php
@@ -3,10 +3,9 @@
 namespace Teazee\Spec\Provider;
 
 use Http\Client\HttpClient;
-use Teazee\Model\TimeZone;
+use Teazee\Model\ZoneInfo;
 use Teazee\Provider\TimeZoneDB;
 use VCR\VCR;
-use DateTimeZone;
 use RuntimeException;
 
 describe (TimeZoneDB::class, function () {
@@ -36,7 +35,7 @@ describe (TimeZoneDB::class, function () {
         });
 
         it ('->find() returns a TimeZone', function () {
-            expect ($this->tz)->toBeAnInstanceOf(TimeZone::class);
+            expect ($this->tz)->toBeAnInstanceOf(ZoneInfo::class);
         });
 
         it ('->find() has a timestamp in utc', function () {

--- a/src/Model/ZoneInfo.php
+++ b/src/Model/ZoneInfo.php
@@ -16,7 +16,7 @@ use DateTimeZone;
 /**
  * @author Michael Crumm <mike@crumm.net>
  */
-final class TimeZone
+final class ZoneInfo extends DateTimeZone
 {
     /**
      * @var string
@@ -39,11 +39,6 @@ final class TimeZone
     private $utcOffset;
 
     /**
-     * @var DateTimeZone
-     */
-    private $dateTimeZone;
-
-    /**
      * @var DateTimeImmutable
      */
     private $dateTime;
@@ -51,22 +46,23 @@ final class TimeZone
     /**
      * TimeZone Constructor.
      *
-     * @param DateTimeZone $zone      DateTimeZone.
+     * @param string $timezone Timezone identifier.
      * @param bool         $dst       Whether or not this TimeZone is in DST.
      * @param int          $utcOffset Offset from UTC.
      * @param int          $timestamp UNIX timestamp.
      * @param string       $country   Country code.
      */
-    public function __construct(DateTimeZone $zone, $dst, $utcOffset, $timestamp, $country = null)
+    public function __construct($timezone, $dst, $utcOffset, $timestamp, $country = null)
     {
-        $this->dateTimeZone = $zone;
+        parent::__construct($timezone);
+
         $this->dst          = $dst ? (bool) $dst : null;
         $this->utcOffset    = $utcOffset ? (int) $utcOffset : null;
         $this->timestamp    = $timestamp ? (int) $timestamp : null;
-        $this->country      = $country ?: $this->dateTimeZone->getLocation()['country_code'];
+        $this->country      = $country ?: $this->getLocation()['country_code'];
 
         if ($this->timestamp) {
-            $this->dateTime = (new \DateTimeImmutable('@'.$this->timestamp))->setTimezone($zone);
+            $this->dateTime = (new \DateTimeImmutable('@'.$this->timestamp))->setTimezone($this);
         }
     }
 
@@ -81,16 +77,6 @@ final class TimeZone
     }
 
     /**
-     * Returns the timezone name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->dateTimeZone->getName();
-    }
-
-    /**
      * Returns a DateTimeImmutable for the provided timestamp.
      *
      * @return DateTimeImmutable
@@ -98,16 +84,6 @@ final class TimeZone
     public function getDateTime()
     {
         return $this->dateTime;
-    }
-
-    /**
-     * Returns the DateTimeZone for this TimeZone.
-     *
-     * @return DateTimeZone
-     */
-    public function getDateTimeZone()
-    {
-        return $this->dateTimeZone;
     }
 
     /**

--- a/src/Model/ZoneInfoFactory.php
+++ b/src/Model/ZoneInfoFactory.php
@@ -10,26 +10,24 @@
 
 namespace Teazee\Model;
 
-use DateTimeZone;
-
 /**
  * @author Michael Crumm <mike@crumm.net>
  */
-class TimeZoneFactory
+final class ZoneInfoFactory
 {
     /**
-     * Creates a TimeZone object from an array of parameters.
+     * Creates a ZoneInfo object from an array of parameters.
      *
      * @param array $data
      *
-     * @return TimeZone
+     * @return ZoneInfo
      *
      * @throws \Exception When given an invalid time zone identifier.
      */
     public function create($data)
     {
-        return new TimeZone(
-            new DateTimeZone($this->getValue($data, 'id')),
+        return new ZoneInfo(
+            $this->getValue($data, 'id'),
             $this->getValue($data, 'dst'),
             $this->getValue($data, 'utcOffset'),
             $this->getValue($data, 'timestamp'),

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -10,8 +10,8 @@
 
 namespace Teazee\Provider;
 
-use Teazee\Model\TimeZone;
-use Teazee\Model\TimeZoneFactory;
+use Teazee\Model\ZoneInfo;
+use Teazee\Model\ZoneInfoFactory;
 
 /**
  * @author Michael Crumm <mike@crumm.net>
@@ -19,7 +19,7 @@ use Teazee\Model\TimeZoneFactory;
 abstract class AbstractProvider implements Provider
 {
     /**
-     * @var TimeZoneFactory
+     * @var ZoneInfoFactory
      */
     private $factory;
 
@@ -28,11 +28,11 @@ abstract class AbstractProvider implements Provider
      */
     public function __construct()
     {
-        $this->factory = new TimeZoneFactory();
+        $this->factory = new ZoneInfoFactory();
     }
 
     /**
-     * Returns the default values for creating a TimeZone.
+     * Returns the default values for creating ZoneInfo.
      *
      * @return array
      */
@@ -47,11 +47,11 @@ abstract class AbstractProvider implements Provider
     }
 
     /**
-     * Creates a TimeZone from the given parameters via the TimeZoneFactory.
+     * Creates ZoneInfo from the given parameters via the ZoneInfoFactory.
      *
      * @param array $data
      *
-     * @return TimeZone
+     * @return ZoneInfo
      */
     protected function returnResult(array $data)
     {

--- a/src/Provider/TimeZoneDB.php
+++ b/src/Provider/TimeZoneDB.php
@@ -11,7 +11,7 @@
 namespace Teazee\Provider;
 
 use Http\Client\HttpClient;
-use Teazee\Model\TimeZone;
+use Teazee\Model\ZoneInfo;
 
 /**
  * @author Michael Crumm <mike@crumm.net>
@@ -51,13 +51,13 @@ class TimeZoneDB extends AbstractHttpProvider
     }
 
     /**
-     * Returns a TimeZone for the specified location and timestamp.
+     * Returns ZoneInfo for the specified location and timestamp.
      *
      * @param string|float $lat       Coordinate latitude.
      * @param string|float $lng       Coordinate longitude.
      * @param int          $timestamp UNIX timestamp used to determine Daylight Savings Time.
      *
-     * @return TimeZone
+     * @return ZoneInfo
      */
     public function find($lat, $lng, $timestamp = null)
     {

--- a/src/Teazee.php
+++ b/src/Teazee.php
@@ -10,7 +10,7 @@
 
 namespace Teazee;
 
-use Teazee\Model\TimeZone;
+use Teazee\Model\ZoneInfo;
 
 /**
  * @author Michael Crumm <mike@crumm.net>
@@ -29,7 +29,7 @@ interface Teazee
      * @param string|float $lng       Longitude coordinate.
      * @param int          $timestamp Timestamp used to determine daylight savings time.
      *
-     * @return TimeZone
+     * @return ZoneInfo
      */
     public function find($lat, $lng, $timestamp);
 }


### PR DESCRIPTION
`ZoneInfo` replaces `TimeZone` as the model returned by all providers.

`ZoneInfo` extends PHP's built-in [`DateTimeZone`](http://php.net/manual/en/class.datetimezone.php) object, and can therefore
be used as a drop-in replacement for `DateTimeZone` in a user's codebase.

This PR also marks `ZoneInfoFactory` as `final`.
